### PR TITLE
Need to reference the appropriate forked version of stupidedi

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,4 +42,4 @@ end
 # Use debugger
 # gem 'debugger', group: [:development, :test]
 
-gem 'stupidedi', '=1.2.2ds'
+gem 'stupidedi', github: 'skaczor/stupidedi'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git://github.com/skaczor/stupidedi.git
+  revision: 5f622f11134737c3962f316d4253f49068186dd8
+  specs:
+    stupidedi (1.2.2)
+      cantor (~> 1.2)
+      term-ansicolor (~> 1.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -90,15 +98,12 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    stupidedi (1.2.2ds)
-      cantor (~> 1.2)
-      term-ansicolor (~> 1.3)
-    term-ansicolor (1.3.0)
+    term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
-    tins (1.3.0)
+    tins (1.8.1)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -119,6 +124,9 @@ DEPENDENCIES
   rails (= 4.0.5)
   sass-rails (~> 4.0.2)
   sdoc
-  stupidedi (= 1.2.2ds)
+  stupidedi!
   turbolinks
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
In order for the tests to pass. Version 1.2.2ds of stupidedi doesn't exist.  The skaczor/stupidedi fork contains the appropriate fixes for the REF element.
